### PR TITLE
feat(shouldprocess): replace -DryRun with SupportsShouldProcess in both scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          echo "tag=${TAG:-v0.0.0}" >> $GITHUB_OUTPUT
+
+      - name: Determine version bump
+        id: bump
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          BUMP="none"
+
+          # Breaking change: type! in title, or BREAKING CHANGE in body
+          if echo "$PR_TITLE" | grep -qE '^[a-z]+(\([^)]+\))?!:' \
+          || echo "$PR_BODY" | grep -q 'BREAKING CHANGE:'; then
+            BUMP="major"
+          elif echo "$PR_TITLE" | grep -qE '^feat(\([^)]+\))?:'; then
+            BUMP="minor"
+          elif echo "$PR_TITLE" | grep -qE '^(fix|perf)(\([^)]+\))?:'; then
+            BUMP="patch"
+          fi
+
+          echo "bump=$BUMP" >> $GITHUB_OUTPUT
+          echo "Bump level: $BUMP (PR: $PR_TITLE)"
+
+      - name: Compute next version
+        if: steps.bump.outputs.bump != 'none'
+        id: next_version
+        run: |
+          VERSION="${{ steps.latest_tag.outputs.tag }#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          case "${{ steps.bump.outputs.bump }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
+          echo "version=v${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_OUTPUT
+
+      - name: Tag and release
+        if: steps.bump.outputs.bump != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.next_version.outputs.version }}"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes "See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `Rename-Photos.ps1` — replaced custom `-DryRun` switch with standard `[CmdletBinding(SupportsShouldProcess)]`; use `-WhatIf` to preview renames and `-Confirm` to prompt before each rename
+- `Build-Trips.ps1` — added `[CmdletBinding(SupportsShouldProcess)]`; use `-WhatIf` to preview the CSV write
+
+### Removed
+- `Rename-Photos.ps1` — `-DryRun` parameter
+
 ## [0.1.0] - 2026-03-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,3 +52,18 @@ See [PLAN.md](../PLAN.md) for the full implementation plan, issue groupings, and
 
 `CHANGELOG.md` is maintained by hand following [Keep a Changelog](https://keepachangelog.com/) conventions — do not regenerate it from commit history.
 
+## Releases
+
+Releases are cut automatically by `.github/workflows/release.yml` when a PR is merged to `main`. The version bump is derived from the squash commit title (i.e. the PR title):
+
+| PR title prefix | Bump |
+|-----------------|------|
+| `type!:` or `BREAKING CHANGE:` in body | major |
+| `feat:` / `feat(scope):` | minor |
+| `fix:` / `perf:` | patch |
+| `chore`, `docs`, `ci`, `test`, `refactor`, `style` | none |
+
+**Requirements:**
+- PRs must be merged using **squash merge** so the PR title becomes the commit on `main`.
+- PR titles must follow Conventional Commits — the workflow uses the title to determine the bump level.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,13 +37,12 @@ When adding new file references in either script, follow this same pattern — n
 
 ## Testing
 
-Use the `-DryRun` flag on `Rename-Photos.ps1` to preview renames without making changes:
+Use `-WhatIf` to preview actions without making changes, or `-Confirm` to prompt before each action:
 
 ```powershell
-.\scripts\Rename-Photos.ps1 -DryRun
+.\scripts\Rename-Photos.ps1 -WhatIf
+.\scripts\Build-Trips.ps1 -WhatIf
 ```
-
-`Build-Trips.ps1` has no dry-run mode; running it only writes `trips.csv` which is gitignored.
 
 ## Implementation plan
 

--- a/scripts/Build-Trips.ps1
+++ b/scripts/Build-Trips.ps1
@@ -31,7 +31,9 @@
 .EXAMPLE
     .\Build-Trips.ps1
     .\Build-Trips.ps1 -RoadFactor 1.30 -TolerancePct 0.25
+    .\Build-Trips.ps1 -WhatIf
 #>
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [string]$Folder          = "",
     [string]$LocationsJson   = "$PSScriptRoot\..\config\locations.json",
@@ -368,22 +370,24 @@ if ($null -ne $pending) {
     }
 }
 
-# Export CSV
-$trips | Export-Csv -Path $tripsOut -NoTypeInformation -Encoding utf8
-
 # Summary
 $auto     = ($trips | Where-Object { $_.Status -eq "auto"     }).Count
 $review   = ($trips | Where-Object { $_.Status -eq "review"   }).Count
 $unpaired = ($trips | Where-Object { $_.Status -eq "unpaired" }).Count
 $stops    = ($trips | Where-Object { $_.Status -eq "stop"     }).Count
 
-Write-Host ""
-Write-Host "Trips written to: $tripsOut"
 Write-Host "  Auto-matched : $auto"
 Write-Host "  Needs review : $review"
 Write-Host "  Unpaired     : $unpaired"
 Write-Host "  Stops (ref)  : $stops"
-if ($review -gt 0 -or $unpaired -gt 0) {
+
+# Export CSV
+if ($PSCmdlet.ShouldProcess($tripsOut, "Write trips CSV")) {
+    $trips | Export-Csv -Path $tripsOut -NoTypeInformation -Encoding utf8
     Write-Host ""
-    Write-Host "Open trips.csv and manually complete rows where Status = 'review' or 'unpaired'."
+    Write-Host "Trips written to: $tripsOut"
+    if ($review -gt 0 -or $unpaired -gt 0) {
+        Write-Host ""
+        Write-Host "Open trips.csv and manually complete rows where Status = 'review' or 'unpaired'."
+    }
 }

--- a/scripts/Rename-Photos.ps1
+++ b/scripts/Rename-Photos.ps1
@@ -31,21 +31,19 @@
     Maximum plausible miles for a single trip. OCR readings that exceed the previous known-good
     odometer by more than (gaps + 1) * MaxTripMiles are flagged as suspect.
 
-.PARAMETER DryRun
-    Preview renames without making changes.
-
 .EXAMPLE
-    .\Rename-Photos.ps1 -DryRun
+    .\Rename-Photos.ps1 -WhatIf
     .\Rename-Photos.ps1
-    .\Rename-Photos.ps1 -Folder "D:\Photos\Odometer" -DryRun
+    .\Rename-Photos.ps1 -Folder "D:\Photos\Odometer" -WhatIf
+    .\Rename-Photos.ps1 -Confirm
 #>
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [string]$Folder                  = "",
     [string]$LocationsJson           = "$PSScriptRoot\..\config\locations.json",
     [string]$ExifToolPath            = "$PSScriptRoot\..\exiftool-13.53_64\exiftool.exe",
     [double]$ProximityThresholdMiles = 1.0,
-    [int]$MaxTripMiles               = 250,
-    [switch]$DryRun
+    [int]$MaxTripMiles               = 250
 )
 
 Set-StrictMode -Version Latest
@@ -345,27 +343,23 @@ foreach ($file in $photos) {
         $counter++
     }
 
-    # --- Rename (or dry-run) --------------------------------------------
-    if ($DryRun) {
-        Write-Host "  [DRY RUN] $($file.Name) -> $newName"
-    }
-    else {
+    # --- Rename and log -------------------------------------------------
+    if ($PSCmdlet.ShouldProcess($file.FullName, "Rename to $newName")) {
         Rename-Item -Path $file.FullName -NewName $newName
         Write-Host "  Renamed -> $newName"
-    }
 
-    # --- Log ------------------------------------------------------------
-    $logEntries += [PSCustomObject]@{
-        OriginalFile       = $file.Name
-        NewFile            = $newName
-        DateTimeOriginal   = $dateTimeRaw
-        Location           = $locationName
-        Odometer           = $ocr.Reading
-        OdometerConfidence = $ocr.Confidence
-        GPSLat             = $gpsLat
-        GPSLon             = $gpsLon
+        $logEntries += [PSCustomObject]@{
+            OriginalFile       = $file.Name
+            NewFile            = $newName
+            DateTimeOriginal   = $dateTimeRaw
+            Location           = $locationName
+            Odometer           = $ocr.Reading
+            OdometerConfidence = $ocr.Confidence
+            GPSLat             = $gpsLat
+            GPSLon             = $gpsLon
+        }
+        $logEntries | ConvertTo-Json | Out-File $logFile -Encoding utf8
     }
-    $logEntries | ConvertTo-Json | Out-File $logFile -Encoding utf8
 }
 
 Write-Host ""


### PR DESCRIPTION
## Summary
- Replaces custom `-DryRun` switch with standard `[CmdletBinding(SupportsShouldProcess)]` in both scripts; use `-WhatIf` to preview and `-Confirm` to prompt
- Adds automated release workflow that cuts a GitHub release on PR merge based on conventional commit type
- Documents release process and squash merge requirement in CLAUDE.md